### PR TITLE
Remove Gemfile and ruby related ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
-Berksfile.lock
-Gemfile.lock
 .vagrant
-.bundle
 .DS_Store
-gems
-bin

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'vagrant', '~> 1.0.6'
-gem 'berkshelf'
-gem 'multi_json'
-


### PR DESCRIPTION
Should install the latest Vagrant from the installer pkg on the web site rather than the ruby gem (it's outdated).
